### PR TITLE
Replace remaining references to pipenv in the week-01 practical

### DIFF
--- a/practicals/week01/main.tex
+++ b/practicals/week01/main.tex
@@ -625,7 +625,7 @@ When using poetry we need to run it in the following way:
   >> poetry run flask --app todo run
 \end{code}
 
-This command runs the \texttt{flask --app todo run} command inside the pipenv environment with our dependencies installed.
+This command runs the \texttt{flask --app todo run} command inside the poetry environment with our dependencies installed.
 
 This web server is a bit boring though, let's add an endpoint so we can see that it works. In the todo folder, create a folder called views and a file \texttt{routes.py}. Add the following code to  \texttt{routes.py}:
 

--- a/practicals/week01/main.tex
+++ b/practicals/week01/main.tex
@@ -274,7 +274,7 @@ It contains the following information:
 \begin{description}
     \item[200s] Indicate the request was successful, 200 is the most common.
     \item[300s] Redirects the requester to another location.
-    \item[400s] Indicates that the request was wrong, e.g. 404 meaning that thte request was for something that does not exist.
+    \item[400s] Indicates that the request was wrong, e.g. 404 meaning that the request was for something that does not exist.
     \item[500s] Indicates that the server had a problem fulfilling the request.
 \end{description}
 
@@ -612,14 +612,14 @@ Your repository should now look like this:
 \begin{code}[language=bash,numbers=none]{}
   .
   |-- README.md
-  |-- Pipfile
-  |-- Pipfile.lock
+  |-- pyproject.toml
+  |-- poetry.lock
   |-- todo
       |-- __init__.py
 \end{code}
 
 We have created a basic Flask app but how do we run it?
-When using pipenv we need to run it in the following way:
+When using poetry we need to run it in the following way:
 
 \begin{code}[language=bash,numbers=none]{}
   >> poetry run flask --app todo run
@@ -683,7 +683,7 @@ If you run into any issues, make sure your files are in the following structure 
 \begin{code}[language=bash,numbers=none]{}
   .
   |-- README.md
-  |-- pyproject
+  |-- pyproject.toml
   |-- poetry.lock
   |-- todo
       |-- __init__.py


### PR DESCRIPTION
Hi, I just went through the first week practical and noticed a couple references to pipenv even though it appears to be no longer used in favour of poetry.

Luckily I am familiar with both poetry and pipenv so could recognise where it had been transitioned, but can imagine this one tripping people up if they're unfamiliar with python environments.