### PR TITLE
Fixed typo in example POST method

### DIFF
--- a/practicals/week01/main.tex
+++ b/practicals/week01/main.tex
@@ -927,7 +927,7 @@ These were our read only methods, now let's get to the mutating methods. First i
         "deadline_at": "2023-02-27T00:00:00",
         "created_at": "2023-02-20T00:00:00",
         "updated_at": "2023-02-20T00:00:00"
-      }, 201)
+      }), 201
 \end{code}
 
 You will notice that currently this function is the same as the GET request but in future weeks we will build out the functionality to actually create a todo. Next is our endpoint to update a todo. In the \texttt{routes.py} file, add the following code to the bottom of the file:


### PR DESCRIPTION
In practical 1 worksheet: A closing parenthesis was moved so that the example code returns the JSON object and the response code (201). The example code previously returned the response code as part of the JSON object. This resulted in students failing the GitHub workflow test for the method when committing.